### PR TITLE
Add comments for tool invocations

### DIFF
--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -43,7 +43,7 @@ class ToolCallAgent(ReActAgent):
             self.messages += [user_msg]
 
         try:
-            # Get response with tool options
+            # Call the LLM with available tools to determine the next action
             response = await self.llm.ask_tool(
                 messages=self.messages,
                 system_msgs=(
@@ -176,7 +176,7 @@ class ToolCallAgent(ReActAgent):
             # Parse arguments
             args = json.loads(command.function.arguments or "{}")
 
-            # Execute the tool
+            # Execute the selected tool with provided arguments
             logger.info(f"🔧 Activating tool: '{name}'...")
             result = await self.available_tools.execute(name=name, tool_input=args)
 

--- a/app/flow/planning.py
+++ b/app/flow/planning.py
@@ -173,7 +173,7 @@ class PlanningFlow(BaseFlow):
                     # Ensure plan_id is set correctly and execute the tool
                     args["plan_id"] = self.active_plan_id
 
-                    # Execute the tool via ToolCollection instead of directly
+                    # Execute the planning tool with the parsed arguments
                     result = await self.planning_tool.execute(**args)
 
                     logger.info(f"Plan creation result: {str(result)}")
@@ -182,7 +182,7 @@ class PlanningFlow(BaseFlow):
         # If execution reached here, create a default plan
         logger.warning("Creating default plan")
 
-        # Create default plan using the ToolCollection
+        # Create a default plan by invoking the planning tool
         await self.planning_tool.execute(
             **{
                 "command": "create",
@@ -230,6 +230,7 @@ class PlanningFlow(BaseFlow):
 
                     # Mark current step as in_progress
                     try:
+                        # Mark the step as in progress using the planning tool
                         await self.planning_tool.execute(
                             command="mark_step",
                             plan_id=self.active_plan_id,
@@ -291,7 +292,7 @@ class PlanningFlow(BaseFlow):
             return
 
         try:
-            # Mark the step as completed
+            # Mark the step as completed via the planning tool
             await self.planning_tool.execute(
                 command="mark_step",
                 plan_id=self.active_plan_id,
@@ -319,6 +320,7 @@ class PlanningFlow(BaseFlow):
     async def _get_plan_text(self) -> str:
         """Get the current plan as formatted text."""
         try:
+            # Retrieve the current plan text via the planning tool
             result = await self.planning_tool.execute(
                 command="get", plan_id=self.active_plan_id
             )

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -43,6 +43,7 @@ class MCPServer:
         # Define the async function to be registered
         async def tool_method(**kwargs):
             logger.info(f"Executing {tool_name}: {kwargs}")
+            # Invoke the registered tool with the provided arguments
             result = await tool.execute(**kwargs)
 
             logger.info(f"Result of {tool_name}: {result}")

--- a/app/tool/bash.py
+++ b/app/tool/bash.py
@@ -154,5 +154,6 @@ class Bash(BaseTool):
 
 if __name__ == "__main__":
     bash = Bash()
+    # Example usage: execute a simple command through the Bash tool
     rst = asyncio.run(bash.execute("ls -l"))
     print(rst)

--- a/app/tool/browser_use_tool.py
+++ b/app/tool/browser_use_tool.py
@@ -253,7 +253,8 @@ class BrowserUseTool(BaseTool, Generic[Context]):
                         return ToolResult(
                             error="Query is required for 'web_search' action"
                         )
-                    # Execute the web search and return results directly without browser navigation
+                    # Execute the web search tool and return results directly without
+                    # navigating in the browser
                     search_response = await self.web_search_tool.execute(
                         query=query, fetch_content=True, num_results=1
                     )
@@ -427,7 +428,7 @@ Page content:
                         },
                     }
 
-                    # Use LLM to extract content with required function calling
+                    # Use LLM's tool calling capability to extract content from the page
                     response = await self.llm.ask_tool(
                         messages,
                         tools=[extraction_function],

--- a/app/tool/chart_visualization/python_execute.py
+++ b/app/tool/chart_visualization/python_execute.py
@@ -33,4 +33,5 @@ class NormalPythonExecute(PythonExecute):
     }
 
     async def execute(self, code: str, code_type: str | None = None, timeout=5):
+        # Delegate execution to the parent Python execution tool
         return await super().execute(code, timeout)

--- a/app/tool/web_search.py
+++ b/app/tool/web_search.py
@@ -410,6 +410,7 @@ class WebSearch(BaseTool):
 
 if __name__ == "__main__":
     web_search = WebSearch()
+    # Run the web search tool directly when executing this file
     search_response = asyncio.run(
         web_search.execute(
             query="Python programming", fetch_content=True, num_results=1


### PR DESCRIPTION
## Summary
- add notes when calling tools in `ToolCallAgent`
- comment planning tool usage
- clarify web search and llm tool calls in browser tool
- document tool invocation in MCP server
- add example usage comments for Bash and WebSearch
- note delegation in chart visualization tool

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdffdaa48326abb837832202d6f9